### PR TITLE
feat: add statsd arguments to gunicorn for stats collection

### DIFF
--- a/kubernetes-manifests/contacts.yaml
+++ b/kubernetes-manifests/contacts.yaml
@@ -22,6 +22,10 @@ spec:
           mountPath: "/root/.ssh"
           readOnly: true
         env:
+        - name: STATSD_HOST
+          value: "statsd-prometheus-statsd-exporter.prometheus.svc.cluster.local:9125"
+        - name: STATSD_PREFIX
+          value: bos.contacts
         - name: VERSION
           value: "v0.4.3"
         - name: PORT

--- a/kubernetes-manifests/frontend.yaml
+++ b/kubernetes-manifests/frontend.yaml
@@ -22,6 +22,10 @@ spec:
           mountPath: "/root/.ssh"
           readOnly: true
         env:
+        - name: STATSD_HOST
+          value: "statsd-prometheus-statsd-exporter.prometheus.svc.cluster.local:9125"
+        - name: STATSD_PREFIX
+          value: bos.frontend
         - name: VERSION
           value: "v0.4.3"
         - name: PORT

--- a/kubernetes-manifests/userservice.yaml
+++ b/kubernetes-manifests/userservice.yaml
@@ -25,6 +25,10 @@ spec:
         - name: http-server
           containerPort: 8080
         env:
+        - name: STATSD_HOST
+          value: "statsd-prometheus-statsd-exporter.prometheus.svc.cluster.local:9125"
+        - name: STATSD_PREFIX
+          value: bos.userservice
         - name: VERSION
           value: "v0.4.3"
         - name: PORT

--- a/src/contacts/Dockerfile
+++ b/src/contacts/Dockerfile
@@ -52,5 +52,8 @@ COPY logging.conf /logging.conf
 CMD gunicorn \
     -b :$PORT \
     --threads $THREADS \
+    --statsd-host=statsd-prometheus-statsd-exporter.prometheus.svc.cluster.local:9125 \
+    --statsd-prefix=bos.contacts \
     --log-config /logging.conf \
     --log-level=$LOG_LEVEL "contacts:create_app()"
+

--- a/src/contacts/Dockerfile
+++ b/src/contacts/Dockerfile
@@ -52,8 +52,8 @@ COPY logging.conf /logging.conf
 CMD gunicorn \
     -b :$PORT \
     --threads $THREADS \
-    --statsd-host=statsd-prometheus-statsd-exporter.prometheus.svc.cluster.local:9125 \
-    --statsd-prefix=bos.contacts \
+    --statsd-host=$STATSD_HOST \
+    --statsd-prefix=$STATSD_PREFIX \
     --log-config /logging.conf \
     --log-level=$LOG_LEVEL "contacts:create_app()"
 

--- a/src/frontend/Dockerfile
+++ b/src/frontend/Dockerfile
@@ -49,4 +49,11 @@ COPY *.py /app/
 COPY logging.conf /logging.conf
 
 # Start server using gunicorn
-CMD gunicorn -b :$PORT --threads $THREADS --log-config /logging.conf --log-level=$LOG_LEVEL "frontend:create_app()"
+CMD gunicorn \
+    -b :$PORT \
+    --threads $THREADS \
+    --statsd-host=statsd-prometheus-statsd-exporter.prometheus.svc.cluster.local:9125 \
+    --statsd-prefix=bos.frontend \
+    --log-config /logging.conf \
+    --log-level=$LOG_LEVEL \
+    "frontend:create_app()"

--- a/src/frontend/Dockerfile
+++ b/src/frontend/Dockerfile
@@ -52,8 +52,8 @@ COPY logging.conf /logging.conf
 CMD gunicorn \
     -b :$PORT \
     --threads $THREADS \
-    --statsd-host=statsd-prometheus-statsd-exporter.prometheus.svc.cluster.local:9125 \
-    --statsd-prefix=bos.frontend \
+    --statsd-host=$STATSD_HOST \
+    --statsd-prefix=$STATSD_PREFIX \
     --log-config /logging.conf \
     --log-level=$LOG_LEVEL \
     "frontend:create_app()"

--- a/src/userservice/Dockerfile
+++ b/src/userservice/Dockerfile
@@ -55,8 +55,8 @@ COPY logging.conf /logging.conf
 CMD gunicorn \
     -b :$PORT \
     --threads $THREADS \
-    --statsd-host=statsd-prometheus-statsd-exporter.prometheus.svc.cluster.local:9125 \
-    --statsd-prefix=bos.userservice \
+    --statsd-host=$STATSD_HOST \
+    --statsd-prefix=$STATSD_PREFIX \
     --log-config /logging.conf \
     --log-level=$LOG_LEVEL \
     "userservice:create_app()"

--- a/src/userservice/Dockerfile
+++ b/src/userservice/Dockerfile
@@ -52,4 +52,12 @@ COPY *.py /app/
 COPY logging.conf /logging.conf
 
 # Start server using gunicorn
-CMD gunicorn -b :$PORT --threads $THREADS --log-config /logging.conf --log-level=$LOG_LEVEL "userservice:create_app()"
+CMD gunicorn \
+    -b :$PORT \
+    --threads $THREADS \
+    --statsd-host=statsd-prometheus-statsd-exporter.prometheus.svc.cluster.local:9125 \
+    --statsd-prefix=bos.userservice \
+    --log-config /logging.conf \
+    --log-level=$LOG_LEVEL \
+    "userservice:create_app()"
+


### PR DESCRIPTION
### Proposed changes
This change adds the necessary arguments to the `gunicorn` invocation to enable statsd generation and direct these stats to the collector in the prometheus namespace in the MARA project.

The lines added are:
    ```
    --statsd-host=statsd-prometheus-statsd-exporter.prometheus.svc.cluster.local:9125 \
    --statsd-prefix=XXXX 
    ```

These images have been built and tested to validate that statsd data is being generated and scraped by prometheus.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [X] I have written my commit messages in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [X] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [X] I have added tests (when possible) that prove my fix is effective or that my feature works
- [X] I have checked that all unit tests pass after adding my changes
- [X] I have updated necessary documentation
- [X] I have rebased my branch onto master
- [X] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
